### PR TITLE
Feat/improve operetta parsing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ authors = [{ name = "Lorenzo Cerrone", email = "lorenzo.cerrone@uzh.ch" }]
 requires-python = ">=3.11,<3.15"
 
 dependencies = [
-    "ome-zarr-converters-tools>=0.7.0,<0.8.0",
+    "ome-zarr-converters-tools>=0.7.1,<0.8.0",
     "fractal-task-tools>=0.3.0,<0.4.0",
     "ngio>=0.5.3,<0.6.0",
     "zarrs",

--- a/src/fractal_uzh_converters/__FRACTAL_MANIFEST__.json
+++ b/src/fractal_uzh_converters/__FRACTAL_MANIFEST__.json
@@ -157,17 +157,24 @@
             "additionalProperties": false,
             "description": "Options for the OME-Zarr conversion process.",
             "properties": {
+              "writer_mode": {
+                "$ref": "#/$defs/WriterMode",
+                "default": "By FOV",
+                "title": "Writer Mode",
+                "description": "Mode for writing data during conversion. - By Tile: Write data one tile at a time. This consumes less memory, but may be slower. - By Tile (Using Dask): Write tiles in parallel using Dask. This is usually faster than writing by tile sequentially, but may consume more memory. - By FOV: Write data one field of view at a time. This may the best compromise between speed and memory usage in most cases. - By FOV (Using Dask): Write fields of view in parallel using Dask. This is usually faster than writing by FOV sequentially, but may consume more memory. - In Memory: Load all data into memory before writing."
+              },
               "tiling_mode": {
                 "$ref": "#/$defs/TilingMode",
                 "default": "Auto",
                 "title": "Tiling Mode",
                 "description": "Tiling mode to use during conversion. - Auto: Automatically determine if Snap to Grid is possible, otherwise use Snap to Corners. - Snap to Grid: Tile images to fit a regular grid. This is only possible if image positions align to a grid (potentially with overlap). - Snap to Corners: Tile images to fit a grid defined by the corner positions. - Inplace: Write tiles in their original positions without tiling. This may lead to artifacts if microscope stage positions are not precise. - No Tiling: Each field of view is written as a single OME-Zarr."
               },
-              "writer_mode": {
-                "$ref": "#/$defs/WriterMode",
-                "default": "By FOV",
-                "title": "Writer Mode",
-                "description": "Mode for writing data during conversion. - By Tile: Write data one tile at a time. This consumes less memory, but may be slower. - By Tile (Using Dask): Write tiles in parallel using Dask. This is usually faster than writing by tile sequentially, but may consume more memory. - By FOV: Write data one field of view at a time. This may the best compromise between speed and memory usage in most cases. - By FOV (Using Dask): Write fields of view in parallel using Dask. This is usually faster than writing by FOV sequentially, but may consume more memory. - In Memory: Load all data into memory before writing."
+              "tiling_tolerance": {
+                "default": 0,
+                "minimum": 0,
+                "title": "Tiling Tolerance (in pixels)",
+                "type": "number",
+                "description": "Tolerance in pixels for determining if Snap to Grid is possible. This accounts for minor jitter in microscope stage positions when determining if Snap to Grid tiling can be applied."
               },
               "alignment_correction": {
                 "$ref": "#/$defs/AlignmentCorrections",
@@ -597,8 +604,9 @@
           "converter_options": {
             "$ref": "#/$defs/ConverterOptions",
             "default": {
-              "tiling_mode": "Auto",
               "writer_mode": "By FOV",
+              "tiling_mode": "Auto",
+              "tiling_tolerance": 0.0,
               "alignment_correction": {
                 "align_t": false,
                 "align_xy": false,
@@ -704,17 +712,24 @@
             "additionalProperties": false,
             "description": "Options for the OME-Zarr conversion process.",
             "properties": {
+              "writer_mode": {
+                "$ref": "#/$defs/WriterMode",
+                "default": "By FOV",
+                "title": "Writer Mode",
+                "description": "Mode for writing data during conversion. - By Tile: Write data one tile at a time. This consumes less memory, but may be slower. - By Tile (Using Dask): Write tiles in parallel using Dask. This is usually faster than writing by tile sequentially, but may consume more memory. - By FOV: Write data one field of view at a time. This may the best compromise between speed and memory usage in most cases. - By FOV (Using Dask): Write fields of view in parallel using Dask. This is usually faster than writing by FOV sequentially, but may consume more memory. - In Memory: Load all data into memory before writing."
+              },
               "tiling_mode": {
                 "$ref": "#/$defs/TilingMode",
                 "default": "Auto",
                 "title": "Tiling Mode",
                 "description": "Tiling mode to use during conversion. - Auto: Automatically determine if Snap to Grid is possible, otherwise use Snap to Corners. - Snap to Grid: Tile images to fit a regular grid. This is only possible if image positions align to a grid (potentially with overlap). - Snap to Corners: Tile images to fit a grid defined by the corner positions. - Inplace: Write tiles in their original positions without tiling. This may lead to artifacts if microscope stage positions are not precise. - No Tiling: Each field of view is written as a single OME-Zarr."
               },
-              "writer_mode": {
-                "$ref": "#/$defs/WriterMode",
-                "default": "By FOV",
-                "title": "Writer Mode",
-                "description": "Mode for writing data during conversion. - By Tile: Write data one tile at a time. This consumes less memory, but may be slower. - By Tile (Using Dask): Write tiles in parallel using Dask. This is usually faster than writing by tile sequentially, but may consume more memory. - By FOV: Write data one field of view at a time. This may the best compromise between speed and memory usage in most cases. - By FOV (Using Dask): Write fields of view in parallel using Dask. This is usually faster than writing by FOV sequentially, but may consume more memory. - In Memory: Load all data into memory before writing."
+              "tiling_tolerance": {
+                "default": 0,
+                "minimum": 0,
+                "title": "Tiling Tolerance (in pixels)",
+                "type": "number",
+                "description": "Tolerance in pixels for determining if Snap to Grid is possible. This accounts for minor jitter in microscope stage positions when determining if Snap to Grid tiling can be applied."
               },
               "alignment_correction": {
                 "$ref": "#/$defs/AlignmentCorrections",
@@ -1138,17 +1153,24 @@
             "additionalProperties": false,
             "description": "Options for the OME-Zarr conversion process.",
             "properties": {
+              "writer_mode": {
+                "$ref": "#/$defs/WriterMode",
+                "default": "By FOV",
+                "title": "Writer Mode",
+                "description": "Mode for writing data during conversion. - By Tile: Write data one tile at a time. This consumes less memory, but may be slower. - By Tile (Using Dask): Write tiles in parallel using Dask. This is usually faster than writing by tile sequentially, but may consume more memory. - By FOV: Write data one field of view at a time. This may the best compromise between speed and memory usage in most cases. - By FOV (Using Dask): Write fields of view in parallel using Dask. This is usually faster than writing by FOV sequentially, but may consume more memory. - In Memory: Load all data into memory before writing."
+              },
               "tiling_mode": {
                 "$ref": "#/$defs/TilingMode",
                 "default": "Auto",
                 "title": "Tiling Mode",
                 "description": "Tiling mode to use during conversion. - Auto: Automatically determine if Snap to Grid is possible, otherwise use Snap to Corners. - Snap to Grid: Tile images to fit a regular grid. This is only possible if image positions align to a grid (potentially with overlap). - Snap to Corners: Tile images to fit a grid defined by the corner positions. - Inplace: Write tiles in their original positions without tiling. This may lead to artifacts if microscope stage positions are not precise. - No Tiling: Each field of view is written as a single OME-Zarr."
               },
-              "writer_mode": {
-                "$ref": "#/$defs/WriterMode",
-                "default": "By FOV",
-                "title": "Writer Mode",
-                "description": "Mode for writing data during conversion. - By Tile: Write data one tile at a time. This consumes less memory, but may be slower. - By Tile (Using Dask): Write tiles in parallel using Dask. This is usually faster than writing by tile sequentially, but may consume more memory. - By FOV: Write data one field of view at a time. This may the best compromise between speed and memory usage in most cases. - By FOV (Using Dask): Write fields of view in parallel using Dask. This is usually faster than writing by FOV sequentially, but may consume more memory. - In Memory: Load all data into memory before writing."
+              "tiling_tolerance": {
+                "default": 0,
+                "minimum": 0,
+                "title": "Tiling Tolerance (in pixels)",
+                "type": "number",
+                "description": "Tolerance in pixels for determining if Snap to Grid is possible. This accounts for minor jitter in microscope stage positions when determining if Snap to Grid tiling can be applied."
               },
               "alignment_correction": {
                 "$ref": "#/$defs/AlignmentCorrections",
@@ -1534,8 +1556,9 @@
           "converter_options": {
             "$ref": "#/$defs/ConverterOptions",
             "default": {
-              "tiling_mode": "Auto",
               "writer_mode": "By FOV",
+              "tiling_mode": "Auto",
+              "tiling_tolerance": 0.0,
               "alignment_correction": {
                 "align_t": false,
                 "align_xy": false,
@@ -1641,17 +1664,24 @@
             "additionalProperties": false,
             "description": "Options for the OME-Zarr conversion process.",
             "properties": {
+              "writer_mode": {
+                "$ref": "#/$defs/WriterMode",
+                "default": "By FOV",
+                "title": "Writer Mode",
+                "description": "Mode for writing data during conversion. - By Tile: Write data one tile at a time. This consumes less memory, but may be slower. - By Tile (Using Dask): Write tiles in parallel using Dask. This is usually faster than writing by tile sequentially, but may consume more memory. - By FOV: Write data one field of view at a time. This may the best compromise between speed and memory usage in most cases. - By FOV (Using Dask): Write fields of view in parallel using Dask. This is usually faster than writing by FOV sequentially, but may consume more memory. - In Memory: Load all data into memory before writing."
+              },
               "tiling_mode": {
                 "$ref": "#/$defs/TilingMode",
                 "default": "Auto",
                 "title": "Tiling Mode",
                 "description": "Tiling mode to use during conversion. - Auto: Automatically determine if Snap to Grid is possible, otherwise use Snap to Corners. - Snap to Grid: Tile images to fit a regular grid. This is only possible if image positions align to a grid (potentially with overlap). - Snap to Corners: Tile images to fit a grid defined by the corner positions. - Inplace: Write tiles in their original positions without tiling. This may lead to artifacts if microscope stage positions are not precise. - No Tiling: Each field of view is written as a single OME-Zarr."
               },
-              "writer_mode": {
-                "$ref": "#/$defs/WriterMode",
-                "default": "By FOV",
-                "title": "Writer Mode",
-                "description": "Mode for writing data during conversion. - By Tile: Write data one tile at a time. This consumes less memory, but may be slower. - By Tile (Using Dask): Write tiles in parallel using Dask. This is usually faster than writing by tile sequentially, but may consume more memory. - By FOV: Write data one field of view at a time. This may the best compromise between speed and memory usage in most cases. - By FOV (Using Dask): Write fields of view in parallel using Dask. This is usually faster than writing by FOV sequentially, but may consume more memory. - In Memory: Load all data into memory before writing."
+              "tiling_tolerance": {
+                "default": 0,
+                "minimum": 0,
+                "title": "Tiling Tolerance (in pixels)",
+                "type": "number",
+                "description": "Tolerance in pixels for determining if Snap to Grid is possible. This accounts for minor jitter in microscope stage positions when determining if Snap to Grid tiling can be applied."
               },
               "alignment_correction": {
                 "$ref": "#/$defs/AlignmentCorrections",
@@ -2042,17 +2072,24 @@
             "additionalProperties": false,
             "description": "Options for the OME-Zarr conversion process.",
             "properties": {
+              "writer_mode": {
+                "$ref": "#/$defs/WriterMode",
+                "default": "By FOV",
+                "title": "Writer Mode",
+                "description": "Mode for writing data during conversion. - By Tile: Write data one tile at a time. This consumes less memory, but may be slower. - By Tile (Using Dask): Write tiles in parallel using Dask. This is usually faster than writing by tile sequentially, but may consume more memory. - By FOV: Write data one field of view at a time. This may the best compromise between speed and memory usage in most cases. - By FOV (Using Dask): Write fields of view in parallel using Dask. This is usually faster than writing by FOV sequentially, but may consume more memory. - In Memory: Load all data into memory before writing."
+              },
               "tiling_mode": {
                 "$ref": "#/$defs/TilingMode",
                 "default": "Auto",
                 "title": "Tiling Mode",
                 "description": "Tiling mode to use during conversion. - Auto: Automatically determine if Snap to Grid is possible, otherwise use Snap to Corners. - Snap to Grid: Tile images to fit a regular grid. This is only possible if image positions align to a grid (potentially with overlap). - Snap to Corners: Tile images to fit a grid defined by the corner positions. - Inplace: Write tiles in their original positions without tiling. This may lead to artifacts if microscope stage positions are not precise. - No Tiling: Each field of view is written as a single OME-Zarr."
               },
-              "writer_mode": {
-                "$ref": "#/$defs/WriterMode",
-                "default": "By FOV",
-                "title": "Writer Mode",
-                "description": "Mode for writing data during conversion. - By Tile: Write data one tile at a time. This consumes less memory, but may be slower. - By Tile (Using Dask): Write tiles in parallel using Dask. This is usually faster than writing by tile sequentially, but may consume more memory. - By FOV: Write data one field of view at a time. This may the best compromise between speed and memory usage in most cases. - By FOV (Using Dask): Write fields of view in parallel using Dask. This is usually faster than writing by FOV sequentially, but may consume more memory. - In Memory: Load all data into memory before writing."
+              "tiling_tolerance": {
+                "default": 0,
+                "minimum": 0,
+                "title": "Tiling Tolerance (in pixels)",
+                "type": "number",
+                "description": "Tolerance in pixels for determining if Snap to Grid is possible. This accounts for minor jitter in microscope stage positions when determining if Snap to Grid tiling can be applied."
               },
               "alignment_correction": {
                 "$ref": "#/$defs/AlignmentCorrections",
@@ -2470,8 +2507,9 @@
           "converter_options": {
             "$ref": "#/$defs/ConverterOptions",
             "default": {
-              "tiling_mode": "Auto",
               "writer_mode": "By FOV",
+              "tiling_mode": "Auto",
+              "tiling_tolerance": 0.0,
               "alignment_correction": {
                 "align_t": false,
                 "align_xy": false,
@@ -2577,17 +2615,24 @@
             "additionalProperties": false,
             "description": "Options for the OME-Zarr conversion process.",
             "properties": {
+              "writer_mode": {
+                "$ref": "#/$defs/WriterMode",
+                "default": "By FOV",
+                "title": "Writer Mode",
+                "description": "Mode for writing data during conversion. - By Tile: Write data one tile at a time. This consumes less memory, but may be slower. - By Tile (Using Dask): Write tiles in parallel using Dask. This is usually faster than writing by tile sequentially, but may consume more memory. - By FOV: Write data one field of view at a time. This may the best compromise between speed and memory usage in most cases. - By FOV (Using Dask): Write fields of view in parallel using Dask. This is usually faster than writing by FOV sequentially, but may consume more memory. - In Memory: Load all data into memory before writing."
+              },
               "tiling_mode": {
                 "$ref": "#/$defs/TilingMode",
                 "default": "Auto",
                 "title": "Tiling Mode",
                 "description": "Tiling mode to use during conversion. - Auto: Automatically determine if Snap to Grid is possible, otherwise use Snap to Corners. - Snap to Grid: Tile images to fit a regular grid. This is only possible if image positions align to a grid (potentially with overlap). - Snap to Corners: Tile images to fit a grid defined by the corner positions. - Inplace: Write tiles in their original positions without tiling. This may lead to artifacts if microscope stage positions are not precise. - No Tiling: Each field of view is written as a single OME-Zarr."
               },
-              "writer_mode": {
-                "$ref": "#/$defs/WriterMode",
-                "default": "By FOV",
-                "title": "Writer Mode",
-                "description": "Mode for writing data during conversion. - By Tile: Write data one tile at a time. This consumes less memory, but may be slower. - By Tile (Using Dask): Write tiles in parallel using Dask. This is usually faster than writing by tile sequentially, but may consume more memory. - By FOV: Write data one field of view at a time. This may the best compromise between speed and memory usage in most cases. - By FOV (Using Dask): Write fields of view in parallel using Dask. This is usually faster than writing by FOV sequentially, but may consume more memory. - In Memory: Load all data into memory before writing."
+              "tiling_tolerance": {
+                "default": 0,
+                "minimum": 0,
+                "title": "Tiling Tolerance (in pixels)",
+                "type": "number",
+                "description": "Tolerance in pixels for determining if Snap to Grid is possible. This accounts for minor jitter in microscope stage positions when determining if Snap to Grid tiling can be applied."
               },
               "alignment_correction": {
                 "$ref": "#/$defs/AlignmentCorrections",

--- a/src/fractal_uzh_converters/operetta/utils.py
+++ b/src/fractal_uzh_converters/operetta/utils.py
@@ -102,6 +102,7 @@ class OperettaImageMeta(BaseModel):
     channel_id: int = Field(..., alias="ChannelID")
     timepoint_id: int = Field(..., alias="TimepointID")
     channel_name: str = Field(..., alias="ChannelName")
+    wavelength_id: MeasureWithUnit = Field(..., alias="MainEmissionWavelength")
     resolution_x: MeasureWithUnit = Field(..., alias="ImageResolutionX")
     resolution_y: MeasureWithUnit = Field(..., alias="ImageResolutionY")
     image_size_x: int = Field(..., alias="ImageSizeX")
@@ -146,7 +147,7 @@ def _parse(path: str) -> dict[str, Any]:
         return xmltodict.parse(
             f.read(),
             process_namespaces=True,
-            namespaces={"http://www.perkinelmer.com/PEHH/HarmonyV5": None},  # type: ignore
+            namespaces={"http://www.perkinelmer.com/PEHH/HarmonyV5": None},
             attr_prefix="",
             cdata_key="Value",
         )
@@ -198,6 +199,15 @@ def _channel_names(images: list[OperettaImageMeta]) -> list[str]:
     return [channel_names[ch_id] for ch_id in sorted(channel_names.keys())]
 
 
+def _wavelength_ids(images: list[OperettaImageMeta]) -> list[str | None]:
+    """Get unique wavelength IDs from image records."""
+    wavelength_ids = {}
+    for img in images:
+        if img.channel_id not in wavelength_ids:
+            wavelength_ids[img.channel_id] = str(int(img.wavelength_id.value))
+    return [wavelength_ids[ch_id] for ch_id in sorted(wavelength_ids.keys())]
+
+
 def _get_data_type(images: list[OperettaImageMeta]) -> DataTypeEnum:
     """Determine data type based on max intensity across all images."""
     if not images:
@@ -220,6 +230,7 @@ def build_acquisition_details(
     pixelsize_x = detail.resolution_x.to_um()
     pixelsize_y = detail.resolution_y.to_um()
     channel_names = _channel_names(images)
+    wavelength_ids = _wavelength_ids(images)
     z_spacing = _get_z_spacing(images)
     t_spacing = 1
     data_type = _get_data_type(images)
@@ -231,7 +242,10 @@ def build_acquisition_details(
             "Using x size for pixelsize."
         )
     axes = default_axes_builder(is_time_series=is_time_series)
-    channels = [ChannelInfo(channel_label=ch_name) for ch_name in channel_names]
+    channels = [
+        ChannelInfo(channel_label=ch_name, wavelength_id=w_id)
+        for (ch_name, w_id) in zip(channel_names, wavelength_ids, strict=True)
+    ]
     acquisition_detail = AcquisitionDetails(
         pixelsize=pixelsize_x,
         z_spacing=z_spacing,

--- a/tests/data/CQ3K/snapshots/2w1p1c1z1t_mip.yaml
+++ b/tests/data/CQ3K/snapshots/2w1p1c1z1t_mip.yaml
@@ -20,6 +20,10 @@ plates:
         - 1.0
         - 0.3242218675179569
         - 0.3242218675179569
+        channel_labels:
+        - channel_0
+        wavelength_ids:
+        - channel_0
         types:
           is_3D: false
         attributes:
@@ -54,6 +58,10 @@ plates:
         - 1.0
         - 0.3242218675179569
         - 0.3242218675179569
+        channel_labels:
+        - channel_0
+        wavelength_ids:
+        - channel_0
         types:
           is_3D: false
         attributes:

--- a/tests/data/OlympusScanR/snapshots/1w1p1c1z1t.yaml
+++ b/tests/data/OlympusScanR/snapshots/1w1p1c1z1t.yaml
@@ -19,6 +19,10 @@ plates:
         - 1.0
         - 0.325
         - 0.325
+        channel_labels:
+        - '405 nm #1'
+        wavelength_ids:
+        - '405 nm #1'
         types:
           is_3D: false
         attributes:

--- a/tests/data/Operetta/snapshots/1w1p1c1z1t.yaml
+++ b/tests/data/Operetta/snapshots/1w1p1c1z1t.yaml
@@ -19,6 +19,10 @@ plates:
         - 1.0
         - 0.5979760809567617
         - 0.5979760809567617
+        channel_labels:
+        - Fluorescein (FITC)
+        wavelength_ids:
+        - '525'
         types:
           is_3D: false
         attributes:

--- a/tests/data/Operetta/snapshots/1w1p1c1z1t_with_condition_table.yaml
+++ b/tests/data/Operetta/snapshots/1w1p1c1z1t_with_condition_table.yaml
@@ -19,18 +19,21 @@ plates:
         - 1.0
         - 0.5979760809567617
         - 0.5979760809567617
+        channel_labels:
+        - Fluorescein (FITC)
+        wavelength_ids:
+        - '525'
         types:
           is_3D: false
         attributes:
-          plate: 1w1p1c1z1t.zarr
-          well: C11
-          acquisition: 0
           drug: drugA & drugB
           concentration: 0.2 & None
           replicate: 1 & 2
           bool_col: True & False
+          plate: 1w1p1c1z1t.zarr
+          well: C11
+          acquisition: 0
         tables:
-          condition_table:
           well_ROI_table:
             rois:
               image:
@@ -42,3 +45,4 @@ plates:
                   max: 44239.0
                   hash: e46dbe494948247754027b354e95dcfd9db0041cabc0a0d25d9db203f5e7406f
                 yx_origin: null
+          condition_table: null

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -42,6 +42,8 @@ class ImageAssertionModel(BaseModel):
     axes: tuple[str, ...]
     shape: tuple[int, ...]
     pixelsize: tuple[float, ...]
+    channel_labels: list[str] = Field(default_factory=list)
+    wavelength_ids: list[str | None] = Field(default_factory=list)
     types: dict[str, bool] = Field(default_factory=dict)
     attributes: dict[str, str | int | float] = Field(default_factory=dict)
     tables: dict[str, TableAssertionModel | None] = Field(default_factory=dict)
@@ -186,6 +188,10 @@ def _post_compute_checks(
             assert image.axes == img_assert.axes
             assert image.shape == img_assert.shape
             assert np.allclose(image.pixel_size.tzyx, img_assert.pixelsize)
+            if img_assert.channel_labels:
+                assert ome_zarr_image.channel_labels == list(img_assert.channel_labels)
+            if img_assert.wavelength_ids:
+                assert ome_zarr_image.wavelength_ids == list(img_assert.wavelength_ids)
             _check_roi_tables(
                 ome_zarr_image=ome_zarr_image,
                 image_assertions=img_assert,
@@ -223,6 +229,8 @@ def _generate_snapshot(
                 "axes": list(image.axes),
                 "shape": list(image.shape),
                 "pixelsize": list(image.pixel_size.tzyx),
+                "channel_labels": ome_zarr_image.channel_labels,
+                "wavelength_ids": ome_zarr_image.wavelength_ids,
             }
 
             full_path = f"{plate_name}/{img_path}"


### PR DESCRIPTION
This pull request introduces support for handling wavelength IDs in the Operetta image metadata parsing and acquisition details building pipeline. The changes ensure that each channel now includes its corresponding wavelength ID, improving metadata completeness and traceability.

**Operetta metadata and acquisition details improvements:**

* Added a new `wavelength_id` field to the `OperettaImageMeta` model to capture the main emission wavelength from the metadata.
* Implemented the `_wavelength_ids` utility function to extract unique wavelength IDs for each channel from the image metadata.
* Updated the `build_acquisition_details` function to include wavelength IDs when constructing the `ChannelInfo` objects, ensuring each channel is associated with its correct wavelength. [[1]](diffhunk://#diff-5cf6c91f69773792a4975486063c33e0c82bca205b5898a92b68d4888c43aefaR233) [[2]](diffhunk://#diff-5cf6c91f69773792a4975486063c33e0c82bca205b5898a92b68d4888c43aefaL234-R248)

**Dependency update:**

* Bumped the minimum version of `ome-zarr-converters-tools` to `0.7.1` in `pyproject.toml` to ensure compatibility with these changes.

**Minor cleanup:**

* Removed an unnecessary `# type: ignore` comment in the XML parsing function for improved code clarity.