### PR TITLE
Warning fix

### DIFF
--- a/src/fractal_uzh_converters/cellvoyager/api.py
+++ b/src/fractal_uzh_converters/cellvoyager/api.py
@@ -8,10 +8,10 @@ from ome_zarr_converters_tools import (
 )
 from ome_zarr_converters_tools.fractal import ImageListUpdateDict
 
+from fractal_uzh_converters.cellvoyager._utils import CellVoyagerAcquisitionModel
 from fractal_uzh_converters.cellvoyager.convert_cellvoyager_init_task import (
     convert_cellvoyager_init_task,
 )
-from fractal_uzh_converters.cellvoyager._utils import CellVoyagerAcquisitionModel
 from fractal_uzh_converters.common.image_in_plate_compute_task import (
     image_in_plate_compute_task,
 )

--- a/src/fractal_uzh_converters/cellvoyager/convert_cellvoyager_init_task.py
+++ b/src/fractal_uzh_converters/cellvoyager/convert_cellvoyager_init_task.py
@@ -66,7 +66,4 @@ def convert_cellvoyager_init_task(
 if __name__ == "__main__":
     from fractal_task_tools.task_wrapper import run_fractal_task
 
-    run_fractal_task(
-        task_function=convert_cellvoyager_init_task,
-        logger_name=logger.name,
-    )
+    run_fractal_task(task_function=convert_cellvoyager_init_task)

--- a/src/fractal_uzh_converters/common/__init__.py
+++ b/src/fractal_uzh_converters/common/__init__.py
@@ -1,11 +1,5 @@
 """Common utilities for fractal UZH converters."""
 
-from fractal_uzh_converters.common.image_in_plate_compute_task import (
-    image_in_plate_compute_task,
-)
-from fractal_uzh_converters.common.single_image_compute_task import (
-    single_image_compute_task,
-)
 from fractal_uzh_converters.common._utils import (
     STANDARD_ROWS_NAMES,
     BaseAcquisitionModel,
@@ -13,6 +7,12 @@ from fractal_uzh_converters.common._utils import (
     SingleBaseAcquisitionModel,
     get_attributes_from_condition_table,
     parse_acquisitions,
+)
+from fractal_uzh_converters.common.image_in_plate_compute_task import (
+    image_in_plate_compute_task,
+)
+from fractal_uzh_converters.common.single_image_compute_task import (
+    single_image_compute_task,
 )
 
 __all__ = [

--- a/src/fractal_uzh_converters/common/image_in_plate_compute_task.py
+++ b/src/fractal_uzh_converters/common/image_in_plate_compute_task.py
@@ -44,4 +44,4 @@ def image_in_plate_compute_task(
 if __name__ == "__main__":
     from fractal_task_tools.task_wrapper import run_fractal_task
 
-    run_fractal_task(task_function=image_in_plate_compute_task, logger_name=logger.name)
+    run_fractal_task(task_function=image_in_plate_compute_task)

--- a/src/fractal_uzh_converters/common/single_image_compute_task.py
+++ b/src/fractal_uzh_converters/common/single_image_compute_task.py
@@ -44,4 +44,4 @@ def single_image_compute_task(
 if __name__ == "__main__":
     from fractal_task_tools.task_wrapper import run_fractal_task
 
-    run_fractal_task(task_function=single_image_compute_task, logger_name=logger.name)
+    run_fractal_task(task_function=single_image_compute_task)

--- a/src/fractal_uzh_converters/cq3k/api.py
+++ b/src/fractal_uzh_converters/cq3k/api.py
@@ -11,8 +11,8 @@ from ome_zarr_converters_tools.fractal import ImageListUpdateDict
 from fractal_uzh_converters.common.image_in_plate_compute_task import (
     image_in_plate_compute_task,
 )
-from fractal_uzh_converters.cq3k.convert_cq3k_init_task import convert_cq3k_init_task
 from fractal_uzh_converters.cq3k._utils import CQ3KAcquisitionModel
+from fractal_uzh_converters.cq3k.convert_cq3k_init_task import convert_cq3k_init_task
 
 
 def convert_cq3k(

--- a/src/fractal_uzh_converters/cq3k/convert_cq3k_init_task.py
+++ b/src/fractal_uzh_converters/cq3k/convert_cq3k_init_task.py
@@ -66,4 +66,4 @@ def convert_cq3k_init_task(
 if __name__ == "__main__":
     from fractal_task_tools.task_wrapper import run_fractal_task
 
-    run_fractal_task(task_function=convert_cq3k_init_task, logger_name=logger.name)
+    run_fractal_task(task_function=convert_cq3k_init_task)

--- a/src/fractal_uzh_converters/custom_tiff/api.py
+++ b/src/fractal_uzh_converters/custom_tiff/api.py
@@ -14,15 +14,15 @@ from fractal_uzh_converters.common.image_in_plate_compute_task import (
 from fractal_uzh_converters.common.single_image_compute_task import (
     single_image_compute_task,
 )
+from fractal_uzh_converters.custom_tiff._utils import (
+    HcsTiffAcquisitionModel,
+    SingleTiffAcquisitionModel,
+)
 from fractal_uzh_converters.custom_tiff.convert_hcs_tiff_init_task import (
     convert_hcs_tiff_init_task,
 )
 from fractal_uzh_converters.custom_tiff.convert_single_tiff_init_task import (
     convert_single_tiff_init_task,
-)
-from fractal_uzh_converters.custom_tiff._utils import (
-    HcsTiffAcquisitionModel,
-    SingleTiffAcquisitionModel,
 )
 
 

--- a/src/fractal_uzh_converters/custom_tiff/convert_hcs_tiff_init_task.py
+++ b/src/fractal_uzh_converters/custom_tiff/convert_hcs_tiff_init_task.py
@@ -66,4 +66,4 @@ def convert_hcs_tiff_init_task(
 if __name__ == "__main__":
     from fractal_task_tools.task_wrapper import run_fractal_task
 
-    run_fractal_task(task_function=convert_hcs_tiff_init_task, logger_name=logger.name)
+    run_fractal_task(task_function=convert_hcs_tiff_init_task)

--- a/src/fractal_uzh_converters/custom_tiff/convert_single_tiff_init_task.py
+++ b/src/fractal_uzh_converters/custom_tiff/convert_single_tiff_init_task.py
@@ -66,6 +66,4 @@ def convert_single_tiff_init_task(
 if __name__ == "__main__":
     from fractal_task_tools.task_wrapper import run_fractal_task
 
-    run_fractal_task(
-        task_function=convert_single_tiff_init_task, logger_name=logger.name
-    )
+    run_fractal_task(task_function=convert_single_tiff_init_task)

--- a/src/fractal_uzh_converters/imagexpress_hcs/api.py
+++ b/src/fractal_uzh_converters/imagexpress_hcs/api.py
@@ -11,11 +11,11 @@ from ome_zarr_converters_tools.fractal import ImageListUpdateDict
 from fractal_uzh_converters.common.image_in_plate_compute_task import (
     image_in_plate_compute_task,
 )
-from fractal_uzh_converters.imagexpress_hcs.convert_imagexpress_hcs_init_task import (
-    convert_imagexpress_hcs_init_task,
-)
 from fractal_uzh_converters.imagexpress_hcs._utils import (
     MDImageXpressHCSaiAcquisitionModel,
+)
+from fractal_uzh_converters.imagexpress_hcs.convert_imagexpress_hcs_init_task import (
+    convert_imagexpress_hcs_init_task,
 )
 
 

--- a/src/fractal_uzh_converters/imagexpress_hcs/convert_imagexpress_hcs_init_task.py
+++ b/src/fractal_uzh_converters/imagexpress_hcs/convert_imagexpress_hcs_init_task.py
@@ -69,6 +69,4 @@ def convert_imagexpress_hcs_init_task(
 if __name__ == "__main__":
     from fractal_task_tools.task_wrapper import run_fractal_task
 
-    run_fractal_task(
-        task_function=convert_imagexpress_hcs_init_task, logger_name=logger.name
-    )
+    run_fractal_task(task_function=convert_imagexpress_hcs_init_task)

--- a/src/fractal_uzh_converters/operetta/api.py
+++ b/src/fractal_uzh_converters/operetta/api.py
@@ -11,10 +11,10 @@ from ome_zarr_converters_tools.fractal import ImageListUpdateDict
 from fractal_uzh_converters.common.image_in_plate_compute_task import (
     image_in_plate_compute_task,
 )
+from fractal_uzh_converters.operetta._utils import OperettaAcquisitionModel
 from fractal_uzh_converters.operetta.convert_operetta_init_task import (
     convert_operetta_init_task,
 )
-from fractal_uzh_converters.operetta._utils import OperettaAcquisitionModel
 
 
 def convert_operetta(

--- a/src/fractal_uzh_converters/operetta/convert_operetta_init_task.py
+++ b/src/fractal_uzh_converters/operetta/convert_operetta_init_task.py
@@ -67,4 +67,4 @@ def convert_operetta_init_task(
 if __name__ == "__main__":
     from fractal_task_tools.task_wrapper import run_fractal_task
 
-    run_fractal_task(task_function=convert_operetta_init_task, logger_name=logger.name)
+    run_fractal_task(task_function=convert_operetta_init_task)

--- a/src/fractal_uzh_converters/scanr/api.py
+++ b/src/fractal_uzh_converters/scanr/api.py
@@ -11,10 +11,10 @@ from ome_zarr_converters_tools.fractal import ImageListUpdateDict
 from fractal_uzh_converters.common.image_in_plate_compute_task import (
     image_in_plate_compute_task,
 )
-from fractal_uzh_converters.scanr.convert_scanr_init_task import convert_scanr_init_task
 from fractal_uzh_converters.scanr._utils import (
     ScanRAcquisitionModel,
 )
+from fractal_uzh_converters.scanr.convert_scanr_init_task import convert_scanr_init_task
 
 
 def convert_scanr(

--- a/src/fractal_uzh_converters/scanr/convert_scanr_init_task.py
+++ b/src/fractal_uzh_converters/scanr/convert_scanr_init_task.py
@@ -66,4 +66,4 @@ def convert_scanr_init_task(
 if __name__ == "__main__":
     from fractal_task_tools.task_wrapper import run_fractal_task
 
-    run_fractal_task(task_function=convert_scanr_init_task, logger_name=logger.name)
+    run_fractal_task(task_function=convert_scanr_init_task)


### PR DESCRIPTION
These warnings were not triggered at test time, as they only trigger when the task is run through the main function. Fixes the warnings like:
```
2026-06-16 14:08:10,683; run_fractal_task; WARNING; `logger_name` function argument is deprecated. The value provided (convert_cq3k_task) will be ignored.
```

Plus some ruff fixes that were applied when I was running the pixi test action