### PR TITLE
s3 compatibility enchance

### DIFF
--- a/src/fractal_uzh_converters/common/_utils.py
+++ b/src/fractal_uzh_converters/common/_utils.py
@@ -4,7 +4,6 @@ import logging
 from typing import Protocol, TypeVar
 
 import polars
-from fsspec.core import split_protocol
 from ome_zarr_converters_tools import (
     AcquisitionOptions,
     AttributeType,
@@ -13,20 +12,13 @@ from ome_zarr_converters_tools import (
 )
 from pydantic import BaseModel, Field
 
+from fractal_uzh_converters.common.url_utils import (
+    url_path_basename,
+)
+
 logger = logging.getLogger("common_converters_compute_task")
 
 STANDARD_ROWS_NAMES = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-
-
-def _path_basename(path: str) -> str:
-    """Last path component, robust to fwd/back slashes and URL protocols.
-
-    Uses ``fsspec`` rather than ``pathlib.Path`` so that remote URLs (e.g.
-    ``s3://bucket/plate``) are not mangled, while still handling Windows
-    backslash separators.
-    """
-    _, stripped = split_protocol(path)
-    return stripped.replace("\\", "/").rstrip("/").split("/")[-1]
 
 
 class BaseAcquisitionModel(BaseModel):
@@ -76,7 +68,7 @@ class HCSBaseAcquisitionModel(BaseAcquisitionModel):
         """Get the normalized plate name."""
         if self.plate_name is not None:
             return self.plate_name
-        name = _path_basename(self.path)
+        name = url_path_basename(self.path)
         return name
 
 
@@ -98,7 +90,7 @@ class SingleBaseAcquisitionModel(BaseAcquisitionModel):
         """Get the normalized image name."""
         if self.image_name is not None:
             return self.image_name
-        name = _path_basename(self.path)
+        name = url_path_basename(self.path)
         return name
 
 

--- a/src/fractal_uzh_converters/common/url_utils.py
+++ b/src/fractal_uzh_converters/common/url_utils.py
@@ -1,0 +1,97 @@
+import os.path
+from pathlib import Path
+
+import fsspec.core
+from ome_zarr_converters_tools import filesystem_for_url
+
+######################################################################
+#
+# Custom URL path utilities
+# TODO(PR): consider moving these to ome-zarr-converters-tools
+#
+######################################################################
+
+
+def url_path_parent(url: str) -> str:
+    """Parent directory of a URL path, robust to fwd/back slashes and URL protocols.
+
+    For remote protocols the first path component after the protocol is considered the
+    network location (like a bucket name for S3). Examples:
+    /path/to/dir/ -> /path/to
+    /path/to/file.txt -> /path/to
+    / -> ValueError: No parent directory for URL: /
+    s3://bucket/dir/ -> s3://bucket
+    s3://bucket/dir/file.txt -> s3://bucket/dir
+    s3://bucket/ -> ValueError: No parent directory for URL: s3://bucket
+    """
+    protocol, path = fsspec.core.split_protocol(url)
+    path = path.rstrip("\\").rstrip("/")
+    if protocol is None:
+        # for local and relative paths it's easier to use pathlib
+        parent = str(Path(path).parent)
+        if parent == path:
+            # This means the path is root (e.g., / or C:\), which has no parent
+            raise ValueError(f"No parent directory for URL: {url}")
+        return parent
+    else:
+        parent = os.path.dirname(path)
+        if parent == "":
+            # for remote urls like s3://bucket, the parent of the bucket is not defined
+            raise ValueError(f"No parent directory for URL: {url}")
+        return f"{protocol}://{parent}"
+
+
+def url_path_basename(url: str) -> str:
+    """Last path component, robust to fwd/back slashes and URL protocols.
+
+    The trailing slash is stripped so that the basename of a directory is returned:
+    /path/to/dir/ -> dir
+    /path/to/dir -> dir
+    /path/to/file.txt -> file.txt
+    """
+    path = fsspec.core.strip_protocol(url)
+    return os.path.basename(path.rstrip("\\").rstrip("/"))
+
+
+def is_url_path_absolute(url: str) -> bool:
+    """Check if a URL path is absolute, robust to fwd/back slashes and URL protocols.
+
+    If the URL starts with a protocol (e.g., "s3://"), it is considered absolute.
+    """
+    protocol, path = fsspec.core.split_protocol(url)
+    # If the URL has a protocol (e.g., "s3://"), we consider it absolute.
+    return True if protocol is not None else Path(path).is_absolute()
+
+
+def join_url_paths(base_url: str, *relative_paths: str) -> str:
+    """Join a base URL with multiple relative paths, ensuring proper slashes.
+
+    Uses ``fsspec`` to preserve URL protocols (e.g. ``s3://``) and normalizes
+    Windows/UNC backslash separators as well as ``.`` / ``..`` components,
+    while never mangling remote URLs.
+    """
+    protocol, base = fsspec.core.split_protocol(base_url)
+    # Unify separators (Windows/UNC) and resolve any "." / ".." segments.
+    # normpath also collapses the redundant slashes from the join itself.
+    joined = os.path.normpath(f"{base}/{'/'.join(relative_paths)}")
+    return joined if protocol is None else f"{protocol}://{joined}"
+
+
+def url_path_glob(*, base_url: str | None, pattern: str) -> list[str]:
+    """Glob a URL path pattern, returning a list of matching URL paths.
+
+    If base_url is None, the pattern is treated as an absolute URL path.
+    """
+    if base_url is not None:
+        pattern = join_url_paths(base_url, pattern)
+    fs = filesystem_for_url(pattern)
+    protocol = fsspec.core.split_protocol(pattern)[0]
+    matched_paths = fs.glob(pattern)
+    if protocol is not None:
+        return [f"{protocol}://{path}" for path in matched_paths]
+    return matched_paths
+
+
+######################################################################
+# end of custom URL path utilities
+######################################################################

--- a/src/fractal_uzh_converters/custom_tiff/_utils.py
+++ b/src/fractal_uzh_converters/custom_tiff/_utils.py
@@ -3,7 +3,6 @@
 import logging
 import tomllib
 import xml.etree.ElementTree as ET
-from pathlib import Path
 
 import pandas as pd
 import tifffile
@@ -12,6 +11,7 @@ from ome_zarr_converters_tools import (
     ChannelInfo,
     ConverterOptions,
     TiledImage,
+    filesystem_for_url,
     tiles_aggregation_pipeline,
 )
 from ome_zarr_converters_tools.core import (
@@ -22,6 +22,12 @@ from ome_zarr_converters_tools.core import (
 from fractal_uzh_converters.common import (
     HCSBaseAcquisitionModel,
     SingleBaseAcquisitionModel,
+)
+from fractal_uzh_converters.common.url_utils import (
+    is_url_path_absolute,
+    join_url_paths,
+    url_path_basename,
+    url_path_parent,
 )
 
 logger = logging.getLogger(__name__)
@@ -114,7 +120,7 @@ def _convert_time_unit(value: float, unit: str) -> float | None:
 _CANONICAL_AXES_ORDER = ["t", "c", "z", "y", "x"]
 
 
-def _validate_series_axes(axes: str, path: Path) -> None:
+def _validate_series_axes(axes: str, path: str) -> None:
     known = set(_CANONICAL_AXES_ORDER)
     unknown = [a for a in axes if a not in known]
     if unknown:
@@ -135,7 +141,7 @@ def _validate_series_axes(axes: str, path: Path) -> None:
         )
 
 
-def _parse_tiff_metadata(path: Path) -> dict:
+def _parse_tiff_metadata(path: str) -> dict:
     """Parse metadata from a TIFF file.
 
     Returns a partial dict with any subset of:
@@ -146,8 +152,9 @@ def _parse_tiff_metadata(path: Path) -> dict:
     of t, c, z, y, x.  All other I/O errors are logged as warnings.
     """
     result: dict = {}
+    fs = filesystem_for_url(path)
     try:
-        with tifffile.TiffFile(str(path)) as tif:
+        with fs.open(path) as f, tifffile.TiffFile(f) as tif:
             # Shape from first page — always tried first as a baseline
             try:
                 page_shape = tif.pages[0].shape
@@ -257,23 +264,29 @@ def _load_tiles_table(acq_path: str) -> pd.DataFrame:
 
     Relative ``file_path`` values are resolved against ``acq_path``.
     """
-    base = Path(acq_path)
-    fpath = base / "tiles.csv"
-    if not fpath.exists():
+    tiles_file_path = join_url_paths(acq_path, "tiles.csv")
+    fs = filesystem_for_url(acq_path)
+    if not fs.exists(tiles_file_path):
         raise FileNotFoundError(f"No tiles.csv found in {acq_path}")
-    df = pd.read_csv(fpath)
-    df["file_path"] = df["file_path"].apply(
-        lambda fp: fp if Path(fp.strip()).is_absolute() else str(base / fp.strip())
-    )
+
+    def path_to_absolute(fp: str) -> str:
+        fp = fp.strip()
+        return fs if is_url_path_absolute(fp) else join_url_paths(acq_path, fp)
+
+    with fs.open(tiles_file_path, "r") as f:
+        df = pd.read_csv(f)
+    df["file_path"] = df["file_path"].apply(path_to_absolute)
+
     return df
 
 
 def _load_toml_raw(acq_path: str) -> dict:
     """Load raw TOML dict from ``acquisition_details.toml`` if present."""
-    toml_path = Path(acq_path) / "acquisition_details.toml"
-    if not toml_path.exists():
+    toml_path = join_url_paths(acq_path, "acquisition_details.toml")
+    fs = filesystem_for_url(acq_path)
+    if not fs.exists(toml_path):
         return {}
-    with open(toml_path, "rb") as f:
+    with fs.open(toml_path, "rb") as f:
         return tomllib.load(f)
 
 
@@ -363,7 +376,7 @@ def parse_hcs_tiff_metadata(
     acq_path = acquisition_model.path
     tiles_table = _load_tiles_table(acq_path)
 
-    first_path = Path(tiles_table["file_path"].iloc[0])
+    first_path = tiles_table["file_path"].iloc[0]
     tiff_meta = _parse_tiff_metadata(first_path)
     tiles_table = _apply_table_defaults(tiles_table, tiff_meta)
 
@@ -395,19 +408,23 @@ def parse_single_tiff_metadata(
 ) -> list[TiledImage]:
     """Parse custom single-image TIFF metadata and return a list of TiledImages."""
     acq_path = acquisition_model.path
-    path = Path(acq_path)
+    fs = filesystem_for_url(acq_path)
 
-    if path.is_file():
-        tiff_meta = _parse_tiff_metadata(path)
+    if fs.isfile(acq_path):
+        tiff_meta = _parse_tiff_metadata(acq_path)
         if "length_x" not in tiff_meta or "length_y" not in tiff_meta:
             raise ValueError(
-                f"Could not determine image dimensions from {path}. "
+                f"Could not determine image dimensions from {acq_path}. "
                 "Ensure the file is a readable TIFF."
             )
+        # Extract filename stem and parent directory from path
+        filename = url_path_basename(acq_path)
+        fov_name = filename.rsplit(".", 1)[0] if "." in filename else filename
+
         tiles_table = pd.DataFrame(
             {
-                "file_path": [str(path.resolve())],
-                "fov_name": [path.stem],
+                "file_path": [acq_path],
+                "fov_name": [fov_name],
                 "start_x": [0.0],
                 "start_y": [0.0],
                 "length_x": [tiff_meta["length_x"]],
@@ -419,12 +436,14 @@ def parse_single_tiff_metadata(
                 ),
             }
         )
+
+        parent_dir = url_path_parent(acq_path)
         acquisition_details = _load_acquisition_details(
-            str(path.parent), tiff_defaults=tiff_meta
+            parent_dir, tiff_defaults=tiff_meta
         )
     else:
         tiles_table = _load_tiles_table(acq_path)
-        first_path = Path(tiles_table["file_path"].iloc[0])
+        first_path = tiles_table["file_path"].iloc[0]
         tiff_meta = _parse_tiff_metadata(first_path)
         tiles_table = _apply_table_defaults(tiles_table, tiff_meta)
         acquisition_details = _load_acquisition_details(

--- a/src/fractal_uzh_converters/imagexpress_hcs/_utils.py
+++ b/src/fractal_uzh_converters/imagexpress_hcs/_utils.py
@@ -3,7 +3,6 @@
 import json
 import logging
 import math
-from pathlib import Path
 
 import pandas as pd
 from ome_zarr_converters_tools import (
@@ -27,6 +26,10 @@ from fractal_uzh_converters.common import (
     STANDARD_ROWS_NAMES,
     HCSBaseAcquisitionModel,
     get_attributes_from_condition_table,
+)
+from fractal_uzh_converters.common.url_utils import (
+    url_path_glob,
+    url_path_parent,
 )
 
 logger = logging.getLogger(__name__)
@@ -72,7 +75,7 @@ class MDImageXpressHCSaiAcquisitionModel(HCSBaseAcquisitionModel):
         v = v.rstrip("/")
         if v.endswith(".mxprotocol"):
             # Strip the filename to get the directory
-            return str(Path(v).parent)
+            return url_path_parent(v)
         return v
 
 
@@ -519,9 +522,9 @@ def parse_md_metadata(
 
     # Discover available experiment directories
     available_dirs = {
-        "montage": list(Path(root_dir).glob("experiment_montage")),
-        "z_stack": list(Path(root_dir).glob("experiment_z_stack")),
-        "standard": list(Path(root_dir).glob("experiment")),
+        "montage": url_path_glob(base_url=root_dir, pattern="experiment_montage"),
+        "z_stack": url_path_glob(base_url=root_dir, pattern="experiment_z_stack"),
+        "standard": url_path_glob(base_url=root_dir, pattern="experiment"),
     }
 
     # Check if any experiment directories exist
@@ -565,7 +568,7 @@ def parse_md_metadata(
     condition_table = acquisition_model.get_condition_table()
 
     # Load experiment metadata from .jdce file
-    jdce_files = sorted(Path(experiment_dir).glob("*.jdce"))
+    jdce_files = sorted(url_path_glob(base_url=experiment_dir, pattern="*.jdce"))
     if len(jdce_files) == 0:
         raise FileNotFoundError(f"No .jdce file found in directory: {experiment_dir}")
     elif len(jdce_files) > 1:
@@ -576,7 +579,7 @@ def parse_md_metadata(
     experiment_meta = parse_jdce_metadata(str(jdce_files[0]))
 
     # Load image records from .csv file
-    csv_files = sorted(Path(experiment_dir).glob("*.csv"))
+    csv_files = sorted(url_path_glob(base_url=experiment_dir, pattern="*.csv"))
     if len(csv_files) == 0:
         raise FileNotFoundError(f"No .csv file found in directory: {experiment_dir}")
     elif len(csv_files) > 1:

--- a/tests/test_tiff_utils.py
+++ b/tests/test_tiff_utils.py
@@ -125,7 +125,7 @@ class TestParseTiffMetadata:
     def test_plain_2d(self, tmp_path):
         path = tmp_path / "plain2d.tif"
         tifffile.imwrite(str(path), np.zeros((64, 128), dtype=np.uint16))
-        meta = _parse_tiff_metadata(path)
+        meta = _parse_tiff_metadata(str(path))
         assert meta["length_y"] == 64
         assert meta["length_x"] == 128
         assert "length_z" not in meta
@@ -141,7 +141,7 @@ class TestParseTiffMetadata:
             photometric="minisblack",
         )
         with pytest.raises(ValueError):
-            _parse_tiff_metadata(path)
+            _parse_tiff_metadata(str(path))
 
     def test_ome_czyx_detects_length_c(self, tmp_path):
         path = tmp_path / "ome_czyx.tif"
@@ -150,7 +150,7 @@ class TestParseTiffMetadata:
             np.zeros((3, 5, 64, 128), dtype=np.uint16),
             axes="CZYX",
         )
-        meta = _parse_tiff_metadata(path)
+        meta = _parse_tiff_metadata(str(path))
         assert meta["length_c"] == 3
         assert meta["length_z"] == 5
         assert meta["length_y"] == 64
@@ -164,7 +164,7 @@ class TestParseTiffMetadata:
             np.zeros((2, 3, 5, 64, 128), dtype=np.uint16),
             axes="TCZYX",
         )
-        meta = _parse_tiff_metadata(path)
+        meta = _parse_tiff_metadata(str(path))
         assert meta["length_t"] == 2
         assert meta["length_c"] == 3
         assert meta["length_z"] == 5
@@ -184,7 +184,7 @@ class TestParseTiffMetadata:
             TimeIncrement=2.5,
             TimeIncrementUnit="s",
         )
-        meta = _parse_tiff_metadata(path)
+        meta = _parse_tiff_metadata(str(path))
         assert meta["pixelsize"] == pytest.approx(0.65)
         assert meta["z_spacing"] == pytest.approx(5.0)
         assert meta["t_spacing"] == pytest.approx(2.5)
@@ -198,7 +198,7 @@ class TestParseTiffMetadata:
             PhysicalSizeX=500.0,
             PhysicalSizeXUnit="nm",
         )
-        meta = _parse_tiff_metadata(path)
+        meta = _parse_tiff_metadata(str(path))
         assert meta["pixelsize"] == pytest.approx(0.5)
 
     def test_imagej_spacing(self, tmp_path):
@@ -211,12 +211,12 @@ class TestParseTiffMetadata:
             spacing=5.0,
             unit="um",
         )
-        meta = _parse_tiff_metadata(path)
+        meta = _parse_tiff_metadata(str(path))
         assert meta["z_spacing"] == pytest.approx(5.0)
         assert meta["pixelsize"] == pytest.approx(0.65, rel=1e-4)
 
     def test_missing_file_returns_empty(self, tmp_path):
-        meta = _parse_tiff_metadata(tmp_path / "nonexistent.tif")
+        meta = _parse_tiff_metadata(str(tmp_path / "nonexistent.tif"))
         assert meta == {}
 
 


### PR DESCRIPTION
This patches the missing parts that prevents converters from full s3 support. 
In order to do this I needed more "url utils" than ome-zarr-converter-tools provides. These are currently in the "common/url_utils.py" and probably will be moved to ome-zarr-converter-tools in the near future.