### PR TITLE
Moving fieldindex field to the ImageMeasurementRecord 

### DIFF
--- a/src/fractal_uzh_converters/cellvoyager/_utils.py
+++ b/src/fractal_uzh_converters/cellvoyager/_utils.py
@@ -70,7 +70,6 @@ class MeasurementRecordBase(Base):
     time: str
     column: int
     row: int
-    field_index: int
     time_point: int
     timeline_index: int
     x: float
@@ -82,6 +81,7 @@ class ImageMeasurementRecord(MeasurementRecordBase):
     """Image measurement record."""
 
     type: Literal["IMG"]
+    field_index: int
     z_index: int
     action_index: int
     action: str
@@ -377,6 +377,7 @@ def parse_cellvoyager_metadata(
 
     for record in records:
         if not isinstance(record, ImageMeasurementRecord):
+            logger.warning(f"Skipping the Error record: {record}")
             continue
 
         row = STANDARD_ROWS_NAMES[record.row - 1]

--- a/tests/data/Yokogawa-CellVoyager/raw/hcs_1w1p1c1z1t/MeasurementData.mlf
+++ b/tests/data/Yokogawa-CellVoyager/raw/hcs_1w1p1c1z1t/MeasurementData.mlf
@@ -1,4 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <bts:MeasurementData bts:Version="1.0" xmlns:bts="http://www.yokogawa.co.jp/BTS/BTSSchema/1.0">
 <bts:MeasurementRecord bts:Type="IMG" bts:Time="2020-08-12T17:36:36.234+02:00" bts:Column="3" bts:Row="2" bts:TimePoint="2" bts:FieldIndex="1" bts:ZIndex="1" bts:TimelineIndex="1" bts:ActionIndex="1" bts:Action="3D" bts:X="-1448.3" bts:Y="1517.7" bts:Z="-2.0" bts:Ch="1">20200812-CardiomyocyteDifferentiation14-Cycle1_B03_T0001F001L01A01Z01C01.tif</bts:MeasurementRecord>
+<bts:MeasurementRecord bts:Type="ERR" bts:Time="2020-01-01T11:00:00.000+01:00" bts:Column="14" bts:Row="3" bts:TimePoint="1" bts:PartialTileIndex="1" bts:TimelineIndex="1" bts:X="-20.0" bts:Y="25.0">AF Error at C14 No. 0 (SAMPLE_PLATE_000000_000000)</bts:MeasurementRecord>
+<bts:MeasurementRecord bts:Type="ERR" bts:Time="2020-01-01T12:00:00.000+01:00" bts:Column="9" bts:Row="14" bts:TimePoint="1" bts:PartialTileIndex="1" bts:TimelineIndex="1" bts:X="-20.0" bts:Y="25.0">AF Error at N09 No. 0 (SAMPLE_PLATE_000000_000000)</bts:MeasurementRecord>
 </bts:MeasurementData>


### PR DESCRIPTION
Moving field_index field to the ImageMeasurementRecord  to properly parse the ERR Records - address the issue #41 
Currently draft as it needs additional tests from my side. Also not sure if the fix should be also apply for the CQ3K converter (no example of such data yet)